### PR TITLE
fix unknown ModuleName SpaceMouse

### DIFF
--- a/Source/SpaceMouseEditor/Private/SSmKeySelector.cpp
+++ b/Source/SpaceMouseEditor/Private/SSmKeySelector.cpp
@@ -236,7 +236,7 @@ FSlateColor SSmKeySelector::GetKeyIconColor() const
 
 FReply SSmKeySelector::ListenForInput()
 {
-    auto& SmModule = FModuleManager::GetModuleChecked<FSpaceMouseEditorModule>("SpaceMouse");
+    auto& SmModule = FModuleManager::GetModuleChecked<FSpaceMouseEditorModule>("SpaceMouseEditor");
     if (!bListenForNextInput && !SmModule.SmManager.IsLearning())
     {
         bListenForNextInput = true;
@@ -248,7 +248,7 @@ FReply SSmKeySelector::ListenForInput()
 
 FReply SSmKeySelector::ProcessHeardInput(FKey KeyHeard)
 {
-    auto& SmModule = FModuleManager::GetModuleChecked<FSpaceMouseEditorModule>("SpaceMouse");
+    auto& SmModule = FModuleManager::GetModuleChecked<FSpaceMouseEditorModule>("SpaceMouseEditor");
     if (bListenForNextInput)	// TODO: Unnecessary. Keep it for safety?
     {
         // Allow cancellation with Esc key


### PR DESCRIPTION
On UE 5.3.2 linux, clicking space mouse key binding button will hit this assert and crash the engine.

Engine/Source/Runtime/Core/Public/Modules/ModuleManager.h
```c++
	template<typename TModuleInterface>
	static TModuleInterface& GetModuleChecked( const FName ModuleName )
	{
		FModuleManager& ModuleManager = FModuleManager::Get();

                // HIT
		checkf(ModuleManager.IsModuleLoaded(ModuleName), TEXT("Tried to get module interface for unloaded module: '%s'"), *(ModuleName.ToString()));
		return static_cast<TModuleInterface&>(*ModuleManager.GetModule(ModuleName));
	}
```

Code related:
```c++
FReply SSmKeySelector::ListenForInput()
FReply SSmKeySelector::ProcessHeardInput(FKey KeyHeard)

    auto& SmModule = FModuleManager::GetModuleChecked<FSpaceMouseEditorModule>("SpaceMouse");
```

Renaming SpaceMouse to SpaceMouseEditor fixed the crash.